### PR TITLE
Add an option to include external audio files in Kodi's <streamdetails>.

### DIFF
--- a/src/main/java/org/tinymediamanager/core/movie/MovieSettings.java
+++ b/src/main/java/org/tinymediamanager/core/movie/MovieSettings.java
@@ -87,6 +87,7 @@ public class MovieSettings extends AbstractModelObject {
   private final static String             BAD_WORDS                                = "badWords";
   private final static String             ENTRY                                    = "entry";
   private final static String             RUNTIME_FROM_MI                          = "runtimeFromMediaInfo";
+  private final static String             INCLUDE_EXTERNAL_AUDIO_STREAMS           = "includeExternalAudioStreams";
   private final static String             ASCII_REPLACEMENT                        = "asciiReplacement";
   private final static String             YEAR_COLUMN_VISIBLE                      = "yearColumnVisible";
   private final static String             NFO_COLUMN_VISIBLE                       = "nfoColumnVisible";
@@ -195,6 +196,7 @@ public class MovieSettings extends AbstractModelObject {
 
   // misc
   private boolean                         runtimeFromMediaInfo                     = false;
+  private boolean                         includeExternalAudioStreams              = false;
   private boolean                         syncTrakt                                = false;
 
   // UI settings
@@ -710,6 +712,17 @@ public class MovieSettings extends AbstractModelObject {
     this.runtimeFromMediaInfo = newValue;
     firePropertyChange(RUNTIME_FROM_MI, oldValue, newValue);
   }
+
+  public boolean isIncludeExternalAudioStreams() {
+    return includeExternalAudioStreams;
+  }
+
+  public void setIncludeExternalAudioStreams(boolean newValue) {
+    boolean oldValue = this.includeExternalAudioStreams;
+    this.includeExternalAudioStreams = newValue;
+    firePropertyChange(INCLUDE_EXTERNAL_AUDIO_STREAMS, oldValue, newValue);
+  }
+
 
   public boolean isAsciiReplacement() {
     return asciiReplacement;

--- a/src/main/java/org/tinymediamanager/core/movie/connector/MovieToKodiNfoConnector.java
+++ b/src/main/java/org/tinymediamanager/core/movie/connector/MovieToKodiNfoConnector.java
@@ -437,16 +437,7 @@ public class MovieToKodiNfoConnector {
 
       kodi.fileinfo.streamdetails.audio.clear();
       for (MediaFileAudioStream as : mediaFile.getAudioStreams()) {
-        Audio audio = new Audio();
-
-        if (StringUtils.isNotBlank(as.getCodec())) {
-          audio.codec = as.getCodec().replaceAll("-", "_");
-        }
-        else {
-          audio.codec = as.getCodec();
-        }
-        audio.language = as.getLanguage();
-        audio.channels = String.valueOf(as.getChannelsAsInt());
+        Audio audio = createAudio(as);
         kodi.fileinfo.streamdetails.audio.add(audio);
       }
 
@@ -458,6 +449,17 @@ public class MovieToKodiNfoConnector {
       }
       break;
     }
+
+    // add external audio to NFO
+    if (MovieModuleManager.MOVIE_SETTINGS.isIncludeExternalAudioStreams()) {
+      for (MediaFile mediaFile : movie.getMediaFiles(MediaFileType.AUDIO)) {
+        for (MediaFileAudioStream as : mediaFile.getAudioStreams()) {
+          Audio audio = createAudio(as);
+          kodi.fileinfo.streamdetails.audio.add(audio);
+        }
+      }
+    }
+
     // add external subtitles to NFO
     for (MediaFile mediaFile : movie.getMediaFiles(MediaFileType.SUBTITLE)) {
       for (MediaFileSubtitle ss : mediaFile.getSubtitles()) {
@@ -471,6 +473,21 @@ public class MovieToKodiNfoConnector {
     kodi.unsupportedElements.addAll(unsupportedTags);
 
     return kodi;
+  }
+
+  private static Audio createAudio(MediaFileAudioStream audioStream) {
+    Audio audio = new Audio();
+
+    if (StringUtils.isNotBlank(audioStream.getCodec())) {
+      audio.codec = audioStream.getCodec().replaceAll("-", "_");
+    }
+    else {
+      audio.codec = audioStream.getCodec();
+    }
+    audio.language = audioStream.getLanguage();
+    audio.channels = String.valueOf(audioStream.getChannelsAsInt());
+
+    return audio;
   }
 
   static void writeNfoFiles(Movie movie, MovieToKodiNfoConnector kodi, List<MovieNfoNaming> nfoNames) {

--- a/src/main/java/org/tinymediamanager/ui/movies/settings/MovieSettingsPanel.java
+++ b/src/main/java/org/tinymediamanager/ui/movies/settings/MovieSettingsPanel.java
@@ -97,6 +97,7 @@ public class MovieSettingsPanel extends ScrollablePanel {
   private JCheckBox                            chckbxNfo;
   private JCheckBox                            chckbxMetadata;
   private JCheckBox                            chckbxRuntimeFromMf;
+  private JCheckBox                            chckbxIncludeExternalAudioStreams;
   private JCheckBox                            chckbxTraktTv;
   private JCheckBox                            chckbxWatched;
   private JCheckBox                            chckbxRating;
@@ -124,11 +125,19 @@ public class MovieSettingsPanel extends ScrollablePanel {
             FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC, FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC,
             FormSpecs.RELATED_GAP_COLSPEC, FormSpecs.DEFAULT_COLSPEC, FormSpecs.RELATED_GAP_COLSPEC, ColumnSpec.decode("default:grow"),
             FormSpecs.RELATED_GAP_COLSPEC, },
-        new RowSpec[] { FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.LABEL_COMPONENT_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-            FormSpecs.UNRELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-            FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-            FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
-            FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC, FormSpecs.RELATED_GAP_ROWSPEC, }));
+        new RowSpec[] {
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.LABEL_COMPONENT_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.UNRELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC, FormSpecs.DEFAULT_ROWSPEC,
+                FormSpecs.RELATED_GAP_ROWSPEC,
+        }));
 
     JLabel lblVisiblecolumns = new JLabel(BUNDLE.getString("Settings.movie.visiblecolumns")); //$NON-NLS-1$
     panelGeneral.add(lblVisiblecolumns, "2, 2, right, default");
@@ -182,20 +191,26 @@ public class MovieSettingsPanel extends ScrollablePanel {
     chckbxRuntimeFromMf = new JCheckBox("");
     panelGeneral.add(chckbxRuntimeFromMf, "4, 12");
 
+    JLabel lblIncludeExternalAudioStreams = new JLabel(BUNDLE.getString("Settings.includeexternalstreamsinnfo"));
+    panelGeneral.add(lblIncludeExternalAudioStreams, "2, 14, right, default");
+
+    chckbxIncludeExternalAudioStreams = new JCheckBox("");
+    panelGeneral.add(chckbxIncludeExternalAudioStreams, "4, 14");
+
     JSeparator separator = new JSeparator();
-    panelGeneral.add(separator, "2, 14, 11, 1");
+    panelGeneral.add(separator, "2, 16, 11, 1");
 
     final JLabel lblAutomaticRename = new JLabel(BUNDLE.getString("Settings.movie.automaticrename")); //$NON-NLS-1$
-    panelGeneral.add(lblAutomaticRename, "2, 16, right, default");
+    panelGeneral.add(lblAutomaticRename, "2, 18, right, default");
 
     chckbxRename = new JCheckBox(BUNDLE.getString("Settings.movie.automaticrename.desc")); //$NON-NLS-1$
-    panelGeneral.add(chckbxRename, "4, 16, 7, 1");
+    panelGeneral.add(chckbxRename, "4, 18, 7, 1");
 
     JLabel lblTraktTv = new JLabel(BUNDLE.getString("Settings.trakt"));//$NON-NLS-1$
-    panelGeneral.add(lblTraktTv, "2, 18");
+    panelGeneral.add(lblTraktTv, "2, 20");
 
     chckbxTraktTv = new JCheckBox("");
-    panelGeneral.add(chckbxTraktTv, "4, 18");
+    panelGeneral.add(chckbxTraktTv, "4, 20");
 
     JButton btnClearTraktTvMovies = new JButton(BUNDLE.getString("Settings.trakt.clearmovies"));//$NON-NLS-1$
     btnClearTraktTvMovies.addActionListener(new ActionListener() {
@@ -540,8 +555,13 @@ public class MovieSettingsPanel extends ScrollablePanel {
     //
     BeanProperty<MovieSettings, Boolean> settingsBeanProperty_8 = BeanProperty.create("runtimeFromMediaInfo");
     AutoBinding<MovieSettings, Boolean, JCheckBox, Boolean> autoBinding_6 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, settings,
-        settingsBeanProperty_8, chckbxRuntimeFromMf, jCheckBoxBeanProperty);
+            settingsBeanProperty_8, chckbxRuntimeFromMf, jCheckBoxBeanProperty);
     autoBinding_6.bind();
+    //
+    BeanProperty<MovieSettings, Boolean> settingsBeanProperty_8a = BeanProperty.create("includeExternalAudioStreams");
+    AutoBinding<MovieSettings, Boolean, JCheckBox, Boolean> autoBinding_6a = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, settings,
+            settingsBeanProperty_8a, chckbxIncludeExternalAudioStreams, jCheckBoxBeanProperty);
+    autoBinding_6a.bind();
     //
     BeanProperty<MovieSettings, Boolean> settingsBeanProperty_9 = BeanProperty.create("yearColumnVisible");
     AutoBinding<MovieSettings, Boolean, JCheckBox, Boolean> autoBinding_7 = Bindings.createAutoBinding(UpdateStrategy.READ_WRITE, settings,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -459,6 +459,7 @@ Settings.macaddress=MAC address
 Settings.movie.badwords=Bad words
 Settings.movie.badwords.hint=Bad words, which will be removed from\r\nthe detected movie name
 Settings.runtimefrommediafile=Prefer runtime from MediaInfo
+Settings.includeexternalstreamsinnfo=Include external audio streams in NFO
 Settings.trailer.preferred=Use preferred trailer settings
 Settings.trailer.source=Trailer source
 Settings.trailer.quality=Trailer quality


### PR DESCRIPTION
Default is off, default behavior is unchanged. When checked then any external audio files will also show up in the <streamdetails> node of the Kodi NFO.

I wasn't sure if the code in MovieSettingsPanel.java was auto-generated or what but I hand-edited it to add the new setting. I also didn't add any localization other than english.