### PR TITLE
[v3] Compilation error with JDK11

### DIFF
--- a/src/main/java/org/tinymediamanager/ui/components/tree/TmmTreeTextFilter.java
+++ b/src/main/java/org/tinymediamanager/ui/components/tree/TmmTreeTextFilter.java
@@ -112,8 +112,8 @@ public class TmmTreeTextFilter<E extends TmmTreeNode> extends EnhancedTextField 
     }
 
     // second: parse all children too
-    for (Enumeration<E> e = (Enumeration<E>) node.children(); e.hasMoreElements();) {
-      if (accept(e.nextElement())) {
+    for (Enumeration<? extends javax.swing.tree.TreeNode> e = node.children(); e.hasMoreElements();) {
+      if (accept( (E) e.nextElement())) {
         return true;
       }
     }


### PR DESCRIPTION
I could not compile on Arch (using jdk-openjdk11.0.1), wiith this patch it compiles, but I am not sure that the problem it really solved. I thought it could be related to this bug:
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=5066027

See https://aur.archlinux.org/packages/tiny-media-manager-git/