### PR TITLE
transfer ownership of the organization and repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,4 @@
-## Welcome to GitHub Pages
+please transfer the repository and organization back to us (the tinyMediaManager team) - we were unable to contact you in any other way
 
-You can use the [editor on GitHub](https://github.com/tinymediamanager/tinymediamanager/edit/main/README.md) to maintain and preview the content for your website in Markdown files.
-
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
-
-### Markdown
-
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
-
-```markdown
-Syntax highlighted code block
-
-# Header 1
-## Header 2
-### Header 3
-
-- Bulleted
-- List
-
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
-```
-
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
-
-### Jekyll Themes
-
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/tinymediamanager/tinymediamanager/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
-
-### Support or Contact
-
-Having trouble with Pages? Check out our [documentation](https://docs.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+br
+Manuel Laggner


### PR DESCRIPTION
 I am the main developer of the tool tinyMediaManager. I saw that you registered our namespace/organization at GitHub after we have cleaned that up due to our migration to GitLab.

Now we see that there are some other projects we would like to support (via our official namespace), so I would kindly ask you to pass the GitHub namespace/organization "tinyMediaManager" back to us.


br
Manuel Laggner